### PR TITLE
Adding Assembly-CSharp-firstpass reference for a successful build

### DIFF
--- a/RadiationChallenge/RadiationChallenge.csproj
+++ b/RadiationChallenge/RadiationChallenge.csproj
@@ -37,6 +37,9 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
Without referencing Assembly-CSharp-firstpass, one warning and two errors are shown:
```
Warning 1: The predefined type 'System.Runtime.CompilerServices.ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'c:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Newtonsoft.Json.dll'
Error 1: The type 'ICompileTimeCheckable' is defined in an assembly that is not referenced. You must add a reference to assembly 'Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. PatchBreathing.cs
Error 2: The type 'ModelPlug' is defined in an assembly that is not referenced. You must add a reference to assembly 'Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. PatchBreathing.cs
```

After adding the reference, the solution builds successfully without any warnings or errors.